### PR TITLE
Remove OpenGL linkedFramework for iOS platform

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1092,7 +1092,7 @@ let package = Package(
         .define("GARCH_EXPORTS", to: "1"),
       ],
       linkerSettings: [
-        .linkedFramework("OpenGL", .when(platforms: [.macOS, .iOS])),
+        .linkedFramework("OpenGL", .when(platforms: [.macOS])),
         .linkedLibrary("glut", .when(platforms: Arch.OS.linux.platform)),
         .linkedLibrary("GL", .when(platforms: Arch.OS.linux.platform)),
         .linkedLibrary("GLU", .when(platforms: Arch.OS.linux.platform)),


### PR DESCRIPTION
### Description of Change(s)

- Removed the linking of the OpenGL framework for the iOS platform as it caused the build to fail when targeting an iOS device.

### Fixes Issue(s)
- Resolves the build failure on iOS devices due to the inability to link the OpenGL framework.

